### PR TITLE
Bump CO client to use the latest API version

### DIFF
--- a/pkg/rest/cluster/amc-cluster-manager-openapi.yaml
+++ b/pkg/rest/cluster/amc-cluster-manager-openapi.yaml
@@ -1,98 +1,95 @@
+---
 # SPDX-FileCopyrightText: 2025 Intel Corporation
-#
 # SPDX-License-Identifier: Apache-2.0
 
 openapi: 3.0.3
 info:
   title: Cluster Manager 2.0
   description: This document defines the schema for the Cluster Manager 2.0 REST API.
-  version: 2.1.0
+  version: 2.1.1-dev
 servers:
-- url: '{apiRoot}'
-  variables:
-    apiRoot:
-      default: https://<multitenancy-gateway-host>
+  - url: '{apiRoot}'
+    variables:
+      apiRoot:
+        default: https://<multitenancy-gateway-host>
 tags:
-- description: Operations related to managing clusters
-  name: Clusters
-- description: Operations related to managing kubeconfig files of created clusters
-  name: Kubeconfigs
-- description: Operations related to managing cluster templates
-  name: Cluster Templates
-- description: Operations related to checking the health status of the CM REST API
-  name: Health Check
+  - description: Operations related to managing clusters
+    name: Clusters
+  - description: Operations related to managing kubeconfig files of created clusters
+    name: Kubeconfigs
+  - description: Operations related to managing cluster templates
+    name: Cluster Templates
+  - description: Operations related to checking the health status of the CM REST API
+    name: Health Check
 security:
-- HTTP: []
-- BearerAuth: []
+  - HTTP: []
+  - BearerAuth: []
 paths:
   /v2/projects/{projectName}/clusters:
     get:
       description: Gets all clusters' information.
       parameters:
-      - description: The maximum number of items to return.
-        example: /v2/clusters?pageSize=20
-        in: query
-        name: pageSize
-        schema:
-          default: 20
-          maximum: 100
-          minimum: 0
-          type: integer
-      - description: Index of the first item to return. It is almost always used in
-          conjunction with the 'pageSize' query.
-        example: /v2/clusters?pageSize=20&offset=10
-        in: query
-        name: offset
-        schema:
-          default: 0
-          minimum: 0
-          type: integer
-      - description: |
-          The ordering of the entries. "asc" and "desc" are valid values. If none is specified, "asc" is used.
+        - description: The maximum number of items to return.
+          example: /v2/clusters?pageSize=20
+          in: query
+          name: pageSize
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 0
+            type: integer
+        - description: Index of the first item to return. It is almost always used in conjunction with the 'pageSize' query.
+          example: /v2/clusters?pageSize=20&offset=10
+          in: query
+          name: offset
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - description: |
+            The ordering of the entries. "asc" and "desc" are valid values. If none is specified, "asc" is used.
 
-          Supported fields:
-          - name
-          - kubernetesVersion
-          - providerStatus
-          - lifecyclePhase
-        examples:
-          ascending:
-            description: sort the entries by name entry in ascending order
-            value: /v2/clusters?orderBy="name asc"
-          default:
-            description: Sorts the entries by name in ascending order as default when
-              no order is specified.
-            value: /v2/clusters?orderBy="name"
-          descending:
-            description: sort the entries by name entry in descending order
-            value: /v2/clusters?orderBy="name desc"
-        in: query
-        name: orderBy
-        schema:
-          type: string
-      - description: |
-          Filters the entries based on the filter provided.
+            Supported fields:
+            - name
+            - kubernetesVersion
+            - providerStatus
+            - lifecyclePhase
+          examples:
+            ascending:
+              description: sort the entries by name entry in ascending order
+              value: /v2/clusters?orderBy="name asc"
+            default:
+              description: Sorts the entries by name in ascending order as default when no order is specified.
+              value: /v2/clusters?orderBy="name"
+            descending:
+              description: sort the entries by name entry in descending order
+              value: /v2/clusters?orderBy="name desc"
+          in: query
+          name: orderBy
+          schema:
+            type: string
+        - description: |
+            Filters the entries based on the filter provided.
 
-          Supported fields:
-          - name
-          - kubernetesVersion
-          - providerStatus
-          - lifecyclePhase
-        examples:
-          multiple_filter:
-            description: filter by cluster name with the prefix "foo" or with Kubernetes
-              software v1.27.5.
-            value: /v2/clusters?filter="name=foo* OR kubernetes_version=v2.27.5"
-          single_filter_with_search_prefix:
-            description: filter clusters whose cluster prefix has foo
-            value: /v2/clusters?filter="name=foo*"
-          single_filter_without_search_prefix:
-            description: Filter by the cluster name "foo".
-            value: /v2/clusters?filter="name=foo"
-        in: query
-        name: filter
-        schema:
-          type: string
+            Supported fields:
+            - name
+            - kubernetesVersion
+            - providerStatus
+            - lifecyclePhase
+          examples:
+            multiple_filter:
+              description: filter by cluster name with the prefix "foo" or with Kubernetes software v1.27.5.
+              value: /v2/clusters?filter="name=foo* OR kubernetes_version=v2.27.5"
+            single_filter_with_search_prefix:
+              description: filter clusters whose cluster prefix has foo
+              value: /v2/clusters?filter="name=foo*"
+            single_filter_without_search_prefix:
+              description: Filter by the cluster name "foo".
+              value: /v2/clusters?filter="name=foo"
+          in: query
+          name: filter
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -104,12 +101,11 @@ paths:
                       $ref: '#/components/schemas/ClusterInfo'
                     type: array
                   totalElements:
-                    description: The count of items in the entire list, regardless
-                      of pagination.
+                    description: The count of items in the entire list, regardless of pagination.
                     format: int32
                     type: integer
                 required:
-                - totalElements
+                  - totalElements
                 type: object
           description: OK
         "400":
@@ -117,14 +113,14 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
     parameters:
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
     post:
       description: Creates a cluster.
       requestBody:
@@ -144,7 +140,7 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
   /v2/projects/{projectName}/clusters/{name}:
     delete:
       description: Deletes the cluster {name}.
@@ -158,7 +154,7 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
     get:
       description: Gets the cluster {name} information.
       responses:
@@ -175,23 +171,23 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
     parameters:
-    - example: ""
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 63
-        minLength: 1
-        pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: ""
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
   /v2/projects/{projectName}/clusters/{name}/kubeconfigs:
     get:
       description: Gets the cluster's kubeconfig file by its name {name}.
@@ -211,40 +207,40 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Kubeconfigs
+        - Kubeconfigs
     parameters:
-    - example: ""
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 100
-        minLength: 1
-        pattern: ^[a-zA-Z-_0-9. ]+$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: ""
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 100
+          minLength: 1
+          pattern: ^[a-zA-Z-_0-9. ]+$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
   /v2/projects/{projectName}/clusters/{name}/labels:
     parameters:
-    - example: ""
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 63
-        minLength: 1
-        pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: ""
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
     put:
       description: Updates cluster {name} labels.
       requestBody:
@@ -263,24 +259,24 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
   /v2/projects/{projectName}/clusters/{name}/nodes:
     parameters:
-    - example: ""
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 63
-        minLength: 1
-        pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: ""
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
     put:
       description: Updates cluster {name} nodes.
       requestBody:
@@ -300,7 +296,7 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
   /v2/projects/{projectName}/clusters/{name}/nodes/{nodeId}:
     delete:
       description: Deletes the cluster {name} node {nodeId}.
@@ -314,54 +310,54 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
     parameters:
-    - example: ""
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 63
-        minLength: 1
-        pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
-        type: string
-    - example: 64e797f6-db22-445e-b606-4228d4f1c2bd
-      in: path
-      name: nodeId
-      required: true
-      schema:
-        pattern: ^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$
-        type: string
-    - description: When set to true, force deletes the edge node.
-      example: /v2/clusters/{name}/nodes/{nodeId}?force=true
-      in: query
-      name: force
-      schema:
-        default: false
-        type: boolean
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: ""
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
+          type: string
+      - example: 64e797f6-db22-445e-b606-4228d4f1c2bd
+        in: path
+        name: nodeId
+        required: true
+        schema:
+          pattern: ^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$
+          type: string
+      - description: When set to true, force deletes the edge node.
+        example: /v2/clusters/{name}/nodes/{nodeId}?force=true
+        in: query
+        name: force
+        schema:
+          default: false
+          type: boolean
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
   /v2/projects/{projectName}/clusters/{name}/template:
     parameters:
-    - example: ""
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 63
-        minLength: 1
-        pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: ""
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 63
+          minLength: 1
+          pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
     put:
       description: Updates the cluster {name} template.
       requestBody:
@@ -381,7 +377,7 @@ paths:
         "501":
           $ref: '#/components/responses/501-NotImplemented'
       tags:
-      - Clusters
+        - Clusters
   /v2/projects/{projectName}/clusters/{nodeId}/clusterdetail:
     get:
       description: Gets cluster detailed information by {nodeId}.
@@ -397,21 +393,21 @@ paths:
         "404":
           $ref: '#/components/responses/404-NotFound'
       tags:
-      - Clusters
+        - Clusters
     parameters:
-    - example: 64e797f6-db22-445e-b606-4228d4f1c2bd
-      in: path
-      name: nodeId
-      required: true
-      schema:
-        pattern: ^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - example: 64e797f6-db22-445e-b606-4228d4f1c2bd
+        in: path
+        name: nodeId
+        required: true
+        schema:
+          pattern: ^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
   /v2/projects/{projectName}/clusters/summary:
     get:
       description: Gets all clusters' summarized by their state.
@@ -427,76 +423,72 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Clusters
+        - Clusters
     parameters:
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
   /v2/projects/{projectName}/templates:
     get:
       description: Gets all templates' information
       parameters:
-      - description: When set to true, gets only the default template information
-        example: /v2/templates?default=true
-        in: query
-        name: default
-        schema:
-          default: false
-          type: boolean
-      - description: The maximum number of items to return.
-        example: /v2/templates?pageSize=20
-        in: query
-        name: pageSize
-        schema:
-          default: 20
-          maximum: 100
-          minimum: 0
-          type: integer
-      - description: Index of the first item to return. It is almost always used in
-          conjunction with the 'pageSize' query.
-        example: /v2/templates?pageSize=20&offset=10
-        in: query
-        name: offset
-        schema:
-          default: 0
-          minimum: 0
-          type: integer
-      - description: The ordering of the entries. "asc" and "desc" are valid values.
-          If none is specified, "asc" is used.
-        examples:
-          ascending:
-            description: sort the entries by name entry in ascending order
-            value: /v2/templates?orderBy="name asc"
-          default:
-            description: Sorts the entries by name in ascending order as default when
-              no order is specified.
-            value: /v2/templates?orderBy="name"
-          descending:
-            description: sort the entries by name entry in descending order
-            value: /v2/templates?orderBy="name desc"
-        in: query
-        name: orderBy
-        schema:
-          type: string
-      - description: Filters the entries based on the filter provided.
-        examples:
-          multiple_filter:
-            description: filter by template name with the prefix "foo" or with version
-              v0.0.23
-            value: /v2/templates?filter="name=foo* OR version=v0.0.23"
-          single_filter_with_search_prefix:
-            description: filter templates whose template prefix has foo
-            value: /v2/templates?filter="name=foo*"
-          single_filter_without_search_prefix:
-            description: Filter by the template name "foo".
-            value: /v2/templates?filter="name=foo"
-        in: query
-        name: filter
-        schema:
-          type: string
+        - description: When set to true, gets only the default template information
+          example: /v2/templates?default=true
+          in: query
+          name: default
+          schema:
+            default: false
+            type: boolean
+        - description: The maximum number of items to return.
+          example: /v2/templates?pageSize=20
+          in: query
+          name: pageSize
+          schema:
+            default: 20
+            maximum: 100
+            minimum: 0
+            type: integer
+        - description: Index of the first item to return. It is almost always used in conjunction with the 'pageSize' query.
+          example: /v2/templates?pageSize=20&offset=10
+          in: query
+          name: offset
+          schema:
+            default: 0
+            minimum: 0
+            type: integer
+        - description: The ordering of the entries. "asc" and "desc" are valid values. If none is specified, "asc" is used.
+          examples:
+            ascending:
+              description: sort the entries by name entry in ascending order
+              value: /v2/templates?orderBy="name asc"
+            default:
+              description: Sorts the entries by name in ascending order as default when no order is specified.
+              value: /v2/templates?orderBy="name"
+            descending:
+              description: sort the entries by name entry in descending order
+              value: /v2/templates?orderBy="name desc"
+          in: query
+          name: orderBy
+          schema:
+            type: string
+        - description: Filters the entries based on the filter provided.
+          examples:
+            multiple_filter:
+              description: filter by template name with the prefix "foo" or with version v0.0.23
+              value: /v2/templates?filter="name=foo* OR version=v0.0.23"
+            single_filter_with_search_prefix:
+              description: filter templates whose template prefix has foo
+              value: /v2/templates?filter="name=foo*"
+            single_filter_without_search_prefix:
+              description: Filter by the template name "foo".
+              value: /v2/templates?filter="name=foo"
+          in: query
+          name: filter
+          schema:
+            type: string
       responses:
         "200":
           content:
@@ -511,14 +503,14 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Cluster Templates
+        - Cluster Templates
     parameters:
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
     post:
       description: Import templates
       requestBody:
@@ -540,25 +532,25 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Cluster Templates
+        - Cluster Templates
   /v2/projects/{projectName}/templates/{name}/default:
     parameters:
-    - description: Name of the template
-      example: baseline
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 50
-        minLength: 1
-        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - description: Name of the template
+        example: baseline
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 50
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
     put:
       description: Updates this template as the default template
       requestBody:
@@ -576,7 +568,7 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Cluster Templates
+        - Cluster Templates
   /v2/projects/{projectName}/templates/{name}/versions:
     get:
       description: Gets all versions of templates matching a particular template name
@@ -594,24 +586,24 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Cluster Templates
+        - Cluster Templates
     parameters:
-    - description: Name of the template
-      example: baseline
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 50
-        minLength: 1
-        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - description: Name of the template
+        example: baseline
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 50
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
   /v2/projects/{projectName}/templates/{name}/versions/{version}:
     delete:
       description: Deletes a specific template
@@ -622,10 +614,12 @@ paths:
           $ref: '#/components/responses/400-BadRequest'
         "404":
           $ref: '#/components/responses/404-NotFound'
+        "409":
+          $ref: '#/components/responses/409-Conflict'
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Cluster Templates
+        - Cluster Templates
     get:
       description: Gets a specific template information
       responses:
@@ -642,32 +636,32 @@ paths:
         "500":
           $ref: '#/components/responses/500-InternalServerError'
       tags:
-      - Cluster Templates
+        - Cluster Templates
     parameters:
-    - description: Name of the template
-      example: baseline
-      in: path
-      name: name
-      required: true
-      schema:
-        maxLength: 50
-        minLength: 1
-        pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
-        type: string
-    - description: Version of the template in the format of 'vX.Y.Z'
-      example: v0.1.0
-      in: path
-      name: version
-      required: true
-      schema:
-        pattern: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
-        type: string
-    - description: unique projectName for the resource
-      in: path
-      name: projectName
-      required: true
-      schema:
-        type: string
+      - description: Name of the template
+        example: baseline
+        in: path
+        name: name
+        required: true
+        schema:
+          maxLength: 50
+          minLength: 1
+          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+          type: string
+      - description: Version of the template in the format of 'vX.Y.Z'
+        example: v0.1.0
+        in: path
+        name: version
+        required: true
+        schema:
+          pattern: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
+          type: string
+      - description: unique projectName for the resource
+        in: path
+        name: projectName
+        required: true
+        schema:
+          type: string
 components:
   responses:
     400-BadRequest:
@@ -675,8 +669,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
-      description: Object in payload is not properly formulated or not related to
-        the method.
+      description: Object in payload is not properly formulated or not related to the method.
     401-Unauthorized:
       content:
         application/json:
@@ -700,8 +693,7 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ProblemDetails'
-      description: The provider is currently unable to handle the request due to an
-        internal error
+      description: The provider is currently unable to handle the request due to an internal error
     501-NotImplemented:
       content:
         application/json:
@@ -762,8 +754,7 @@ components:
       properties:
         labels:
           additionalProperties:
-            description: The pattern for the label values. Label key patterns are
-              validated as part of the request handler
+            description: The pattern for the label values. Label key patterns are validated as part of the request handler
             maxLength: 63
             pattern: ^$|^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
             type: string
@@ -776,8 +767,7 @@ components:
       properties:
         labels:
           additionalProperties:
-            description: The pattern for the label values. Label key patterns are
-              validated as part of the request handler.
+            description: The pattern for the label values. Label key patterns are validated as part of the request handler.
             maxLength: 63
             pattern: ^$|^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
             type: string
@@ -799,7 +789,7 @@ components:
           pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
           type: string
       required:
-      - nodes
+        - nodes
       type: object
     ClusterSummary:
       properties:
@@ -824,11 +814,11 @@ components:
           format: int32
           type: integer
       required:
-      - totalClusters
-      - ready
-      - error
-      - inProgress
-      - unknown
+        - totalClusters
+        - ready
+        - error
+        - inProgress
+        - unknown
       type: object
     ClusterTemplateInfo:
       properties:
@@ -847,28 +837,26 @@ components:
           pattern: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-dev)?$
           type: string
       required:
-      - name
-      - version
+        - name
+        - version
       type: object
     DefaultTemplateInfo:
       properties:
         name:
-          description: Name of the template. Not required when setting the default,
-            is available in GET /v1/templates.
+          description: Name of the template. Not required when setting the default, is available in GET /v1/templates.
           example: baseline
           maxLength: 50
           minLength: 1
           pattern: ^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
           type: string
         version:
-          description: Template version. If set to empty, the latest version will
-            be used as default.
+          description: Template version. If set to empty, the latest version will be used as default.
           example: v0.1.0
           maxLength: 63
           pattern: ^$|^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$
           type: string
       required:
-      - version
+        - version
       type: object
     GenericStatus:
       description: A generic status object.
@@ -888,9 +876,9 @@ components:
           type: integer
       readOnly: true
       required:
-      - message
-      - indicator
-      - timestamp
+        - message
+        - indicator
+        - timestamp
       type: object
     KubeconfigInfo:
       properties:
@@ -908,7 +896,7 @@ components:
             type: string
           type: array
       required:
-      - cidrBlocks
+        - cidrBlocks
     NodeInfo:
       properties:
         id:
@@ -929,14 +917,14 @@ components:
         role:
           default: all
           enum:
-          - all
-          - controlplane
-          - worker
+            - all
+            - controlplane
+            - worker
           format: enum
           type: string
       required:
-      - id
-      - role
+        - id
+        - role
       type: object
     ProblemDetails:
       properties:
@@ -947,10 +935,10 @@ components:
     StatusIndicator:
       description: The status indicator.
       enum:
-      - STATUS_INDICATION_UNSPECIFIED
-      - STATUS_INDICATION_ERROR
-      - STATUS_INDICATION_IN_PROGRESS
-      - STATUS_INDICATION_IDLE
+        - STATUS_INDICATION_UNSPECIFIED
+        - STATUS_INDICATION_ERROR
+        - STATUS_INDICATION_IN_PROGRESS
+        - STATUS_INDICATION_IDLE
       format: enum
       readOnly: true
       type: string
@@ -958,11 +946,11 @@ components:
       properties:
         condition:
           enum:
-          - STATUS_CONDITION_UNKNOWN
-          - STATUS_CONDITION_READY
-          - STATUS_CONDITION_NOTREADY
-          - STATUS_CONDITION_PROVISIONING
-          - STATUS_CONDITION_REMOVING
+            - STATUS_CONDITION_UNKNOWN
+            - STATUS_CONDITION_READY
+            - STATUS_CONDITION_NOTREADY
+            - STATUS_CONDITION_PROVISIONING
+            - STATUS_CONDITION_REMOVING
           format: enum
           type: string
         reason:
@@ -977,9 +965,7 @@ components:
             maxLength: 63
             pattern: ^$|^[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9]$
             type: string
-          description: Allows users to specify a list of key/value pairs to be attached
-            to a cluster created with the template. These pairs need to conform to
-            https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+          description: Allows users to specify a list of key/value pairs to be attached to a cluster created with the template. These pairs need to conform to https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
           example:
             default-extension: demo
             dns.sub.domain/key-2: value-2.with.dots
@@ -997,24 +983,24 @@ components:
               agentConfig:
                 kubelet:
                   extraArgs:
-                  - --topology-manager-policy=best-effort
-                  - --cpu-manager-policy=static
-                  - --reserved-cpus=1
-                  - --max-pods=250
-                  - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                    - --topology-manager-policy=best-effort
+                    - --cpu-manager-policy=static
+                    - --reserved-cpus=1
+                    - --max-pods=250
+                    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
               serverConfig:
                 cni: calico
                 disableComponents:
                   kubernetesComponents:
-                  - cloudController
+                    - cloudController
                 etcd:
                   backupConfig: {}
                   extraArgs:
-                  - --cipher-suites=[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256]
+                    - --cipher-suites=[TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256]
                 kubeApiServer:
                   extraArgs:
-                  - --feature-gates=PortForwardWebsockets=true
-                  - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+                    - --feature-gates=PortForwardWebsockets=true
+                    - --tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
                 kubeControllerManager:
                   extraArg: null
                 kubeScheduler:
@@ -1024,8 +1010,9 @@ components:
         controlplaneprovidertype:
           default: rke2
           enum:
-          - kubeadm
-          - rke2
+            - kubeadm
+            - rke2
+            - k3s
           type: string
         description:
           maxLength: 4096
@@ -1034,8 +1021,8 @@ components:
         infraprovidertype:
           default: intel
           enum:
-          - docker
-          - intel
+            - docker
+            - intel
           type: string
         kubernetesVersion:
           maxLength: 63
@@ -1053,9 +1040,9 @@ components:
           pattern: ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-dev)?$
           type: string
       required:
-      - name
-      - version
-      - kubernetesVersion
+        - name
+        - version
+        - kubernetesVersion
       type: object
     TemplateInfoList:
       properties:

--- a/pkg/rest/cluster/client.go
+++ b/pkg/rest/cluster/client.go
@@ -1852,6 +1852,7 @@ type DeleteV2ProjectsProjectNameTemplatesNameVersionsVersionResponse struct {
 	HTTPResponse *http.Response
 	JSON400      *N400BadRequest
 	JSON404      *N404NotFound
+	JSON409      *N409Conflict
 	JSON500      *N500InternalServerError
 }
 
@@ -2778,6 +2779,13 @@ func ParseDeleteV2ProjectsProjectNameTemplatesNameVersionsVersionResponse(rsp *h
 			return nil, err
 		}
 		response.JSON404 = &dest
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 409:
+		var dest N409Conflict
+		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
+			return nil, err
+		}
+		response.JSON409 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 500:
 		var dest N500InternalServerError

--- a/pkg/rest/cluster/types.go
+++ b/pkg/rest/cluster/types.go
@@ -34,6 +34,7 @@ const (
 
 // Defines values for TemplateInfoControlplaneprovidertype.
 const (
+	K3s     TemplateInfoControlplaneprovidertype = "k3s"
 	Kubeadm TemplateInfoControlplaneprovidertype = "kubeadm"
 	Rke2    TemplateInfoControlplaneprovidertype = "rke2"
 )


### PR DESCRIPTION
## Description

Bump CO client to use the latest API version.

## Tests
Manually running the tool.

```
$ go run cmd/orch-cli/main.go list cluster --project itep 
Total clusters found: 199
Clusters in project 'itep':
0. cluster-sn000001 (ready)
1. cluster-sn000002 (ready)
2. cluster-sn000003 (ready)
...
130. cluster-sn000133 (ready)
131. cluster-sn000134 (ready)
132. cluster-sn000135 (ready)
133. cluster-sn000136 (not ready;waiting for control plane provider to indicate the control plane has been initialized)
...
189. cluster-sn000192 (ready)
190. cluster-sn000193 (ready)
191. cluster-sn000194 (not ready;waiting for control plane provider to indicate the control plane has been initialized)
...
198. sn000201 (ready)
```

## Checklist

- [x] Tests passed
- [ ] Documentation updated
