### PR TITLE
Hosts improvements

### DIFF
--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -445,7 +445,6 @@ func runRegisterHostCommand(cmd *cobra.Command, args []string) error {
 // Deletes specific Host - finds a host using resource ID and deletes it
 func runDeleteHostCommand(cmd *cobra.Command, args []string) error {
 	hostID := args[0]
-	_, verbose := getOutputContext(cmd)
 	ctx, hostClient, projectName, err := getInfraServiceContext(cmd)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description

Few improvemnts to hosts implementation discovered during scale testing.

## Changes

### nil checks

Added few new nil checks to prevent `panic: runtime error: invalid memory address or nil pointer dereference`

Before: 
```
$ go run cmd/orch-cli/main.go list host

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x9e6e05]

goroutine 1 [running]:
github.com/open-edge-platform/cli/internal/cli.printHosts({0xcc4fc0, 0xc0000dc210}, 0xc000382360?, 0x0)
        /home/seu/repos/orch-cli/internal/cli/host.go:112 +0x265
github.com/open-edge-platform/cli/internal/cli.runListHostCommand(0xc000352308, {0xbbd90a?, 0x4?, 0xbbd8a2?})
        /home/seu/repos/orch-cli/internal/cli/host.go:356 +0x7bb
github.com/spf13/cobra.(*Command).execute(0xc000352308, {0x11a3fc0, 0x0, 0x0})
        /home/seu/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaaa
github.com/spf13/cobra.(*Command).ExecuteC(0xc00020c308)
        /home/seu/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(...)
        /home/seu/.asdf/installs/golang/1.22.2/packages/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/open-edge-platform/cli/internal/cli.Execute()
        /home/seu/repos/orch-cli/internal/cli/root.go:57 +0x18
main.main()
        /home/seu/repos/orch-cli/cmd/orch-cli/main.go:12 +0xf
exit status 2
```
After:
```
$ go run cmd/orch-cli/main.go list host

Resource ID     Name   Host Status     Serial Number   Operating System                         Site              Workload
host-00200438          Error           sn000436        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-00335314          Error           sn000452        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-00bc150a          Error           sn000165        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-00febbdb          Error           sn000030        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-011b98dd          Not connected   sn000821        Not provisioned                          "site-93209ed5"   null
host-01577497          Error           sn000241        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-016de8dd          Error           sn000555        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-01722b96          Error           sn000246        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-01af5f0a          Not connected   sn000736        Not provisioned                          "site-93209ed5"   null
host-0227f4ee          Error           sn000108        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-02641e20          Error           sn000549        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-029f0634          Error           sn000428        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-02dd03b6          Error           sn000250        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-02ea1c80          Error           sn000441        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-035a2cd2          Not connected   sn000713        Not provisioned                          "site-93209ed5"   null
host-035aa1b3          Error           sn000099        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
host-03923643          Not connected   sn000916        Not provisioned                          "site-93209ed5"   null
host-03c42532          Not connected   sn000790        Not provisioned                          "site-93209ed5"   null
host-03c49ba2          Not connected   sn000896        Not provisioned                          "site-93209ed5"   null
host-0400e343          Error           sn000466        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   null
```
### 'list host' pagination

Added pagination support to `list host` command. Without it only 20 hosts were listed.

Before: 
```
(the same as above)
```
After:
```
$ go run cmd/orch-cli/main.go list host -v

Resource ID     Name   Host Status     Serial Number   Operating System                         Site              Workload          Host ID   UUID                                   Processor   Available Update   Trusted Compute
host-00200438          Error           sn000436        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   Not provisioned             67834728-d2b4-412c-97b9-6a7dac3d4ad2               No update          Not compatible
host-00335314          Error           sn000452        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   Not provisioned             152e1689-b9e8-4f05-a728-95699815d58b                         
...
host-fef2860d          Not connected   sn000566        Not provisioned                          "site-93209ed5"   Not provisioned             8f66efe4-96cb-40d6-8e26-373813181246               No update          Not compatible
host-ff79cd48          Error           sn000049        "Edge Microvisor Toolkit 3.0.20250514"   "site-93209ed5"   Not provisioned             cb494a60-bc78-4633-b1a5-47dd2e888291               No update          Not compatible
host-ffe80f0e          Not connected   sn000641        Not provisioned                          "site-93209ed5"   Not provisioned             00855319-0c78-48d8-a031-1c81d65c9b6a               No update          Not compatible

Total Hosts: 928
```

### extended `delete host` with instance deletion

Default UI behaviour on host deletion is to also delete the instance. This is what usually is intended by the user, hence added the same functionality to the CLI. 

```sh
$ go run cmd/orch-cli/main.go delete host host-ad891c1c -v
Instance inst-8d3c6ebc associated with host deleted successfully
Host host-ad891c1c deleted successfully
```

## Checklist

- [x] Tests passed
- [ ] Documentation updated
