### PR TITLE
Fix clusters force delete

### DIFF
--- a/internal/cli/cluster.go
+++ b/internal/cli/cluster.go
@@ -413,7 +413,7 @@ func forceDeleteCluster(ctx context.Context, hostClient *infra.ClientWithRespons
 		if err != nil {
 			return fmt.Errorf("failed to delete node %s from cluster %s: %w", uuid, clusterName, err)
 		}
-		if resp.HTTPResponse.StatusCode != 204 {
+		if resp.HTTPResponse.StatusCode != 204 && resp.HTTPResponse.StatusCode != 200 {
 			return fmt.Errorf("failed to delete node %s from cluster %s: %s", uuid, clusterName, resp.HTTPResponse.Status)
 		}
 		fmt.Printf("Node %s deleted successfully from cluster %s\n", uuid, clusterName)


### PR DESCRIPTION
## Description

Fix clusters force delete.

```sh
$ orch-cli delete cluster cluster-sn000473 --force
Deleting cluster 'cluster-sn000473' in project 'itep'
Force deleting node 52a6c8d9-629b-4fab-b8bc-d0a28c0d3fb0 from cluster cluster-sn000473
Node 52a6c8d9-629b-4fab-b8bc-d0a28c0d3fb0 deleted successfully from cluster cluster-sn000473
Cluster 'cluster-sn000473' deletion initiated successfully.
```

## Checklist

- [x] Tests passed
- [ ] Documentation updated
