### PR TITLE
add realm role management for users

### DIFF
--- a/internal/cli/mocks/keycloak/keycloak_admin_mock.go
+++ b/internal/cli/mocks/keycloak/keycloak_admin_mock.go
@@ -145,6 +145,41 @@ func CreateKeycloakAdminMock(mctrl *gomock.Controller) interfaces.KeycloakAdminF
 			gomock.Any(), gomock.Any(),
 		).Return(allGroups, nil).AnyTimes()
 
+		allRealmRoles := map[string]kcapi.RoleRepresentation{
+			"org1_proj1_m": {ID: "role-uuid-1", Name: "org1_proj1_m"},
+			"org1_proj2_m": {ID: "role-uuid-2", Name: "org1_proj2_m"},
+		}
+
+		mockClient.EXPECT().GetRealmRoleByName(
+			gomock.Any(), gomock.Any(), gomock.Any(),
+		).DoAndReturn(
+			func(_ context.Context, _ string, roleName string) (*kcapi.RoleRepresentation, error) {
+				if role, ok := allRealmRoles[roleName]; ok {
+					return &role, nil
+				}
+				return nil, fmt.Errorf("realm role %q not found", roleName)
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().ListUserRealmRoles(
+			gomock.Any(), gomock.Any(), gomock.Any(),
+		).DoAndReturn(
+			func(_ context.Context, _ string, userID string) ([]kcapi.RoleRepresentation, error) {
+				if userID == sampleUserID {
+					return []kcapi.RoleRepresentation{allRealmRoles["org1_proj1_m"]}, nil
+				}
+				return []kcapi.RoleRepresentation{}, nil
+			},
+		).AnyTimes()
+
+		mockClient.EXPECT().AddRealmRolesToUser(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		).Return(nil).AnyTimes()
+
+		mockClient.EXPECT().RemoveRealmRolesFromUser(
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		).Return(nil).AnyTimes()
+
 		ctx := context.Background()
 		return ctx, mockClient, "master", nil
 	}

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -35,6 +35,12 @@ orch-cli get user sample-user
 
 # Get user details including group memberships
 orch-cli get user sample-user --groups
+
+# Get user details including realm role assignments
+orch-cli get user sample-user --roles
+
+# Get user details with both groups and roles
+orch-cli get user sample-user --groups --roles
 `
 
 const createUserExamples = `# Create a user with just a username
@@ -74,6 +80,15 @@ orch-cli set user sample-user --remove-group org-admin-group
 
 # Add and remove groups in one command
 orch-cli set user sample-user --add-group edge-manager-group --remove-group edge-operator-group
+
+# Assign a realm role to a user
+orch-cli set user sample-user --add-realm-role "${ORG_UID}_${PROJ_UID}_m"
+
+# Remove a realm role from a user
+orch-cli set user sample-user --remove-realm-role "${ORG_UID}_${PROJ_UID}_m"
+
+# Combine group and realm role changes
+orch-cli set user sample-user --add-group edge-manager-group --add-realm-role "${ORG_UID}_${PROJ_UID}_m"
 `
 
 func printUsers(writer io.Writer, users []keycloak.UserRepresentation, verbose bool) {
@@ -100,7 +115,7 @@ func printUsers(writer io.Writer, users []keycloak.UserRepresentation, verbose b
 	}
 }
 
-func printUser(writer io.Writer, user *keycloak.UserRepresentation, groups []keycloak.GroupRepresentation) {
+func printUser(writer io.Writer, user *keycloak.UserRepresentation, groups []keycloak.GroupRepresentation, roles []keycloak.RoleRepresentation) {
 	if user == nil {
 		fmt.Fprintf(writer, "User not found\n")
 		return
@@ -124,6 +139,14 @@ func printUser(writer io.Writer, user *keycloak.UserRepresentation, groups []key
 			groupNames = append(groupNames, g.Name)
 		}
 		_, _ = fmt.Fprintf(writer, "Groups: \t%s\n", strings.Join(groupNames, ", "))
+	}
+
+	if roles != nil {
+		roleNames := make([]string, 0, len(roles))
+		for _, r := range roles {
+			roleNames = append(roleNames, r.Name)
+		}
+		_, _ = fmt.Fprintf(writer, "Realm Roles: \t%s\n", strings.Join(roleNames, ", "))
 	}
 }
 
@@ -156,6 +179,7 @@ func getGetUserCommand() *cobra.Command {
 		RunE:    runGetUserCommand,
 	}
 	cmd.Flags().Bool("groups", false, "Also list the user's group memberships")
+	cmd.Flags().Bool("roles", false, "Also list the user's realm role assignments")
 	cmd.Flags().String("realm", "master", "Keycloak realm")
 	return cmd
 }
@@ -196,7 +220,7 @@ func getDeleteUserCommand() *cobra.Command {
 func getSetUserCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "user <username> [flags]",
-		Short:   "Update a user (password, group membership)",
+		Short:   "Update a user (password, group membership, realm roles)",
 		Example: setUserExamples,
 		Args:    cobra.ExactArgs(1),
 		Aliases: userAliases,
@@ -207,6 +231,8 @@ func getSetUserCommand() *cobra.Command {
 	cmd.Flags().Bool("temporary-password", false, "If set, user must change password on first login")
 	cmd.Flags().StringSlice("add-group", nil, "Group name(s) to add the user to")
 	cmd.Flags().StringSlice("remove-group", nil, "Group name(s) to remove the user from")
+	cmd.Flags().StringSlice("add-realm-role", nil, "Realm role name(s) to assign to the user")
+	cmd.Flags().StringSlice("remove-realm-role", nil, "Realm role name(s) to remove from the user")
 	cmd.Flags().String("realm", "master", "Keycloak realm")
 	return cmd
 }
@@ -255,7 +281,16 @@ func runGetUserCommand(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	printUser(writer, user, groups)
+	var roles []keycloak.RoleRepresentation
+	showRoles, _ := cmd.Flags().GetBool("roles")
+	if showRoles {
+		roles, err = kcClient.ListUserRealmRoles(ctx, realm, user.ID)
+		if err != nil {
+			return fmt.Errorf("error getting user realm roles: %w", err)
+		}
+	}
+
+	printUser(writer, user, groups, roles)
 	return writer.Flush()
 }
 
@@ -389,6 +424,31 @@ func runSetUserCommand(cmd *cobra.Command, args []string) error {
 			}
 			fmt.Fprintf(cmd.OutOrStdout(), "Removed user %q from group %q\n", username, groupName)
 		}
+	}
+
+	addRoles, _ := cmd.Flags().GetStringSlice("add-realm-role")
+	removeRoles, _ := cmd.Flags().GetStringSlice("remove-realm-role")
+
+	for _, roleName := range addRoles {
+		role, err := kcClient.GetRealmRoleByName(ctx, realm, roleName)
+		if err != nil {
+			return fmt.Errorf("realm role %q not found: %w", roleName, err)
+		}
+		if err := kcClient.AddRealmRolesToUser(ctx, realm, user.ID, []keycloak.RoleRepresentation{*role}); err != nil {
+			return fmt.Errorf("error assigning realm role %q: %w", roleName, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Assigned realm role %q to user %q\n", roleName, username)
+	}
+
+	for _, roleName := range removeRoles {
+		role, err := kcClient.GetRealmRoleByName(ctx, realm, roleName)
+		if err != nil {
+			return fmt.Errorf("realm role %q not found: %w", roleName, err)
+		}
+		if err := kcClient.RemoveRealmRolesFromUser(ctx, realm, user.ID, []keycloak.RoleRepresentation{*role}); err != nil {
+			return fmt.Errorf("error removing realm role %q: %w", roleName, err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Removed realm role %q from user %q\n", roleName, username)
 	}
 
 	return nil

--- a/internal/cli/user.go
+++ b/internal/cli/user.go
@@ -432,7 +432,7 @@ func runSetUserCommand(cmd *cobra.Command, args []string) error {
 	for _, roleName := range addRoles {
 		role, err := kcClient.GetRealmRoleByName(ctx, realm, roleName)
 		if err != nil {
-			return fmt.Errorf("realm role %q not found: %w", roleName, err)
+			return fmt.Errorf("error looking up realm role %q: %w", roleName, err)
 		}
 		if err := kcClient.AddRealmRolesToUser(ctx, realm, user.ID, []keycloak.RoleRepresentation{*role}); err != nil {
 			return fmt.Errorf("error assigning realm role %q: %w", roleName, err)
@@ -443,7 +443,7 @@ func runSetUserCommand(cmd *cobra.Command, args []string) error {
 	for _, roleName := range removeRoles {
 		role, err := kcClient.GetRealmRoleByName(ctx, realm, roleName)
 		if err != nil {
-			return fmt.Errorf("realm role %q not found: %w", roleName, err)
+			return fmt.Errorf("error looking up realm role %q: %w", roleName, err)
 		}
 		if err := kcClient.RemoveRealmRolesFromUser(ctx, realm, user.ID, []keycloak.RoleRepresentation{*role}); err != nil {
 			return fmt.Errorf("error removing realm role %q: %w", roleName, err)

--- a/internal/cli/user_test.go
+++ b/internal/cli/user_test.go
@@ -226,3 +226,71 @@ func (s *CLITestSuite) TestSetUserGroupNotFound() {
 	s.Error(err)
 	s.Contains(err.Error(), "not found")
 }
+
+func (s *CLITestSuite) TestSetUserAddRealmRole() {
+	CArgs := map[string]string{
+		"add-realm-role": "org1_proj1_m",
+	}
+	output, err := s.setUser("sample-user", CArgs)
+	s.NoError(err)
+	s.Contains(output, "Assigned realm role")
+	s.Contains(output, "org1_proj1_m")
+}
+
+func (s *CLITestSuite) TestSetUserRemoveRealmRole() {
+	CArgs := map[string]string{
+		"remove-realm-role": "org1_proj1_m",
+	}
+	output, err := s.setUser("sample-user", CArgs)
+	s.NoError(err)
+	s.Contains(output, "Removed realm role")
+	s.Contains(output, "org1_proj1_m")
+}
+
+func (s *CLITestSuite) TestSetUserRealmRoleNotFound() {
+	CArgs := map[string]string{
+		"add-realm-role": "nonexistent-role",
+	}
+	_, err := s.setUser("sample-user", CArgs)
+	s.Error(err)
+	s.Contains(err.Error(), "not found")
+}
+
+func (s *CLITestSuite) TestSetUserAddGroupAndRealmRole() {
+	CArgs := map[string]string{
+		"add-group":      "edge-manager-group",
+		"add-realm-role": "org1_proj1_m",
+	}
+	output, err := s.setUser("sample-user", CArgs)
+	s.NoError(err)
+	s.Contains(output, "Added user")
+	s.Contains(output, "edge-manager-group")
+	s.Contains(output, "Assigned realm role")
+	s.Contains(output, "org1_proj1_m")
+}
+
+func (s *CLITestSuite) TestGetUserWithRoles() {
+	CArgs := map[string]string{
+		"roles": "true",
+	}
+	getOutput, err := s.getUser("sample-user", CArgs)
+	s.NoError(err)
+
+	parsedOutput := mapGetOutput(getOutput)
+	s.Equal("sample-user", parsedOutput["Username:"])
+	s.Contains(parsedOutput["Realm Roles:"], "org1_proj1_m")
+}
+
+func (s *CLITestSuite) TestGetUserWithGroupsAndRoles() {
+	CArgs := map[string]string{
+		"groups": "true",
+		"roles":  "true",
+	}
+	getOutput, err := s.getUser("sample-user", CArgs)
+	s.NoError(err)
+
+	parsedOutput := mapGetOutput(getOutput)
+	s.Equal("sample-user", parsedOutput["Username:"])
+	s.Contains(parsedOutput["Groups:"], "org-admin-group")
+	s.Contains(parsedOutput["Realm Roles:"], "org1_proj1_m")
+}

--- a/pkg/rest/keycloak/client.go
+++ b/pkg/rest/keycloak/client.go
@@ -27,6 +27,10 @@ type ClientInterface interface {
 	AddUserToGroup(ctx context.Context, realm, userID, groupID string) error
 	RemoveUserFromGroup(ctx context.Context, realm, userID, groupID string) error
 	ListGroups(ctx context.Context, realm string) ([]GroupRepresentation, error)
+	GetRealmRoleByName(ctx context.Context, realm, roleName string) (*RoleRepresentation, error)
+	ListUserRealmRoles(ctx context.Context, realm, userID string) ([]RoleRepresentation, error)
+	AddRealmRolesToUser(ctx context.Context, realm, userID string, roles []RoleRepresentation) error
+	RemoveRealmRolesFromUser(ctx context.Context, realm, userID string, roles []RoleRepresentation) error
 }
 
 // AuthHeaderFunc is a function that injects auth headers into a request.
@@ -260,4 +264,60 @@ func (c *Client) ListGroups(ctx context.Context, realm string) ([]GroupRepresent
 		return nil, fmt.Errorf("failed to decode groups response: %w", err)
 	}
 	return groups, nil
+}
+
+func (c *Client) GetRealmRoleByName(ctx context.Context, realm, roleName string) (*RoleRepresentation, error) {
+	path := fmt.Sprintf("%s/roles/%s", c.adminPath(realm), url.PathEscape(roleName))
+	body, status, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("get realm role %q failed (%d): %s", roleName, status, truncateBody(body, 256))
+	}
+	var role RoleRepresentation
+	if err := json.Unmarshal(body, &role); err != nil {
+		return nil, fmt.Errorf("failed to decode role response: %w", err)
+	}
+	return &role, nil
+}
+
+func (c *Client) ListUserRealmRoles(ctx context.Context, realm, userID string) ([]RoleRepresentation, error) {
+	path := fmt.Sprintf("%s/users/%s/role-mappings/realm", c.adminPath(realm), url.PathEscape(userID))
+	body, status, err := c.doRequest(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return nil, err
+	}
+	if status != http.StatusOK {
+		return nil, fmt.Errorf("list user realm roles failed (%d): %s", status, truncateBody(body, 256))
+	}
+	var roles []RoleRepresentation
+	if err := json.Unmarshal(body, &roles); err != nil {
+		return nil, fmt.Errorf("failed to decode roles response: %w", err)
+	}
+	return roles, nil
+}
+
+func (c *Client) AddRealmRolesToUser(ctx context.Context, realm, userID string, roles []RoleRepresentation) error {
+	path := fmt.Sprintf("%s/users/%s/role-mappings/realm", c.adminPath(realm), url.PathEscape(userID))
+	body, status, err := c.doRequest(ctx, http.MethodPost, path, roles)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return fmt.Errorf("add realm roles to user failed (%d): %s", status, truncateBody(body, 256))
+	}
+	return nil
+}
+
+func (c *Client) RemoveRealmRolesFromUser(ctx context.Context, realm, userID string, roles []RoleRepresentation) error {
+	path := fmt.Sprintf("%s/users/%s/role-mappings/realm", c.adminPath(realm), url.PathEscape(userID))
+	body, status, err := c.doRequest(ctx, http.MethodDelete, path, roles)
+	if err != nil {
+		return err
+	}
+	if status != http.StatusNoContent {
+		return fmt.Errorf("remove realm roles from user failed (%d): %s", status, truncateBody(body, 256))
+	}
+	return nil
 }

--- a/pkg/rest/keycloak/mock_client.go
+++ b/pkg/rest/keycloak/mock_client.go
@@ -179,3 +179,61 @@ func (mr *MockClientInterfaceMockRecorder) ListGroups(ctx, realm interface{}) *g
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListGroups", reflect.TypeOf((*MockClientInterface)(nil).ListGroups), ctx, realm)
 }
+
+// GetRealmRoleByName mocks base method.
+func (m *MockClientInterface) GetRealmRoleByName(ctx context.Context, realm, roleName string) (*RoleRepresentation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRealmRoleByName", ctx, realm, roleName)
+	ret0, _ := ret[0].(*RoleRepresentation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRealmRoleByName indicates an expected call of GetRealmRoleByName.
+func (mr *MockClientInterfaceMockRecorder) GetRealmRoleByName(ctx, realm, roleName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRealmRoleByName", reflect.TypeOf((*MockClientInterface)(nil).GetRealmRoleByName), ctx, realm, roleName)
+}
+
+// ListUserRealmRoles mocks base method.
+func (m *MockClientInterface) ListUserRealmRoles(ctx context.Context, realm, userID string) ([]RoleRepresentation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListUserRealmRoles", ctx, realm, userID)
+	ret0, _ := ret[0].([]RoleRepresentation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListUserRealmRoles indicates an expected call of ListUserRealmRoles.
+func (mr *MockClientInterfaceMockRecorder) ListUserRealmRoles(ctx, realm, userID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserRealmRoles", reflect.TypeOf((*MockClientInterface)(nil).ListUserRealmRoles), ctx, realm, userID)
+}
+
+// AddRealmRolesToUser mocks base method.
+func (m *MockClientInterface) AddRealmRolesToUser(ctx context.Context, realm, userID string, roles []RoleRepresentation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddRealmRolesToUser", ctx, realm, userID, roles)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddRealmRolesToUser indicates an expected call of AddRealmRolesToUser.
+func (mr *MockClientInterfaceMockRecorder) AddRealmRolesToUser(ctx, realm, userID, roles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRealmRolesToUser", reflect.TypeOf((*MockClientInterface)(nil).AddRealmRolesToUser), ctx, realm, userID, roles)
+}
+
+// RemoveRealmRolesFromUser mocks base method.
+func (m *MockClientInterface) RemoveRealmRolesFromUser(ctx context.Context, realm, userID string, roles []RoleRepresentation) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveRealmRolesFromUser", ctx, realm, userID, roles)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveRealmRolesFromUser indicates an expected call of RemoveRealmRolesFromUser.
+func (mr *MockClientInterfaceMockRecorder) RemoveRealmRolesFromUser(ctx, realm, userID, roles interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveRealmRolesFromUser", reflect.TypeOf((*MockClientInterface)(nil).RemoveRealmRolesFromUser), ctx, realm, userID, roles)
+}

--- a/pkg/rest/keycloak/types.go
+++ b/pkg/rest/keycloak/types.go
@@ -20,6 +20,11 @@ type GroupRepresentation struct {
 	Path string `json:"path,omitempty"`
 }
 
+type RoleRepresentation struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
 // CredentialRepresentation is used for password reset requests.
 type CredentialRepresentation struct {
 	Type      string `json:"type"`


### PR DESCRIPTION
## Description

* Add realm role assignment for users via set user --add-realm-role / --remove-realm-role
* Add get user --roles to inspect realm role assignments
* Add password tests covering inline, env var, and prompt fallback paths

This enables assigning Keycloak realm roles (e.g. {orgUID}_{projectUID}_m) directly from the CLI, removing the need to shell out to kcadm.

Example usage

```
# Assign a project membership role
orch-cli set user sample-user --add-realm-role "${ORG_UID}_${PROJ_UID}_m"

# Remove it
orch-cli set user sample-user --remove-realm-role "${ORG_UID}_${PROJ_UID}_m"

# Combine with existing flags
orch-cli set user sample-user --add-group edge-manager-group --add-realm-role "${ORG_UID}_${PROJ_UID}_m"

# Inspect roles
orch-cli get user sample-user --roles --groups
```

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
