### PR TITLE
Update component-test.yml to use SHA for orch-ci version

### DIFF
--- a/.github/workflows/component-test.yml
+++ b/.github/workflows/component-test.yml
@@ -60,7 +60,7 @@ jobs:
           git config --global url."https://${{ secrets.SYS_EMF_GH_TOKEN }}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
 
       - name: Setup asdf and install dependencies
-        uses: open-edge-platform/orch-ci/.github/actions/setup-asdf@main  # zizmor: ignore[unpinned-uses]
+        uses: open-edge-platform/orch-ci/.github/actions/setup-asdf@a95228137803b756aae327668c115db235802982  # v2026.1.3  zizmor: ignore[unpinned-uses]
 
       - name: Checkout app-orch-catalog repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd   # v6.0.2


### PR DESCRIPTION
This pull request makes a small but important change to the GitHub Actions workflow by pinning the `setup-asdf` action to a specific commit hash. This helps improve build reliability and security by ensuring the workflow always uses a known version of the action. 

* [`.github/workflows/component-test.yml`](diffhunk://#diff-839d5f7ccf5828adb1dace93b2bebf21d96362cd494b77c76d6d28b74b5b064aL63-R63): Updated the `setup-asdf` action to use commit `a95228137803b756aae327668c115db235802982` instead of the floating `main` branch.