### PR TITLE
Update post-merge.yaml remove publish artifact

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -30,7 +30,6 @@ jobs:
       run_docker_push: false
       run_helm_build: false
       run_helm_push: false
-      run_artifact_push: true
       run_version_tag: true
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/post-merge.yaml` workflow configuration. The change disables the artifact push step by setting `run_artifact_push` to `false` instead of `true`.