### PR TITLE
Update post-merge.yaml to push to ECR

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -31,7 +31,8 @@ jobs:
       run_helm_build: false
       run_helm_push: false
       run_version_tag: true
-      artifact-publish: true
+      run_artifact_push: true
+      artifact_to_s3: true
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}


### PR DESCRIPTION
This pull request updates the artifact publishing workflow in `.github/workflows/post-merge.yaml` to improve clarity and functionality by renaming and adding job parameters.

Workflow configuration improvements:

* Renamed the `artifact-publish` parameter to `run_artifact_push` for clearer intent and consistency.
* Added a new parameter, `artifact_to_s3`, to enable pushing artifacts to S3 as part of the workflow.