### PR TITLE
Update post-merge.yaml

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -32,7 +32,6 @@ jobs:
       run_helm_push: false
       run_version_tag: true
       run_artifact_push: true
-      artifact_to_s3: true
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}


### PR DESCRIPTION
This pull request makes a small change to the post-merge GitHub Actions workflow by removing the `artifact_to_s3` configuration from the job settings. This likely means that artifacts will no longer be pushed to S3 as part of this workflow.

* [`.github/workflows/post-merge.yaml`](diffhunk://#diff-718495b98036156c667b0e7e9a1bb1535a04a0e87ef400a3274eceb9baff864dL35): Removed the `artifact_to_s3` setting from the job configuration.