### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PKG     	:= github.com/open-edge-platform/cli
 OCI_REPOSITORY 	:= edge-orch/files/orch-cli
 OCI_REGISTRY    ?= 080137407410.dkr.ecr.us-west-2.amazonaws.com
 VERSION         ?= $(shell cat ./VERSION)
+ARTIFACT_FILES := src ./binaries/build/_output/orch-cli
 
 RELEASE_DIR     ?= release
 RELEASE_NAME    ?= orch-cli
@@ -216,8 +217,7 @@ license: reuse-tool
 
 artifact-publish:
 	@echo "TAR orch-cli."
-	FILES := src ./binaries/build/_output/orch-cli
-	tar -czvf orch-cli-package.tar.gz $(FILES)
+	tar -czvf orch-cli-package.tar.gz $(ARTIFACT_FILES)
 
 	@echo "Publishing orch-cli-package.tar.gz to Production Release Service."
 	aws ecr create-repository --region us-west-2 --repository-name ${OCI_REPOSITORY} || true


### PR DESCRIPTION
This pull request makes a minor improvement to the `Makefile` by introducing the `ARTIFACT_FILES` variable to manage the list of files included in the release artifact. This change simplifies and centralizes the artifact file definition, making future updates easier.

* Build process simplification:
  * Defined a new `ARTIFACT_FILES` variable for files to be included in the release artifact, and updated the `artifact-publish` target to use this variable instead of duplicating the file list. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R11) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L219-R220)
