### PR TITLE
Update post-merge.yaml  revert push to release service

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -31,7 +31,6 @@ jobs:
       run_helm_build: false
       run_helm_push: false
       run_version_tag: true
-      run_artifact_push: true
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}


### PR DESCRIPTION
This pull request makes a minor update to the `.github/workflows/post-merge.yaml` workflow configuration by disabling the artifact push step.

- CI/CD workflow configuration:
  * Disabled the `run_artifact_push` step by removing or setting it to false in the post-merge GitHub Actions workflow.