### PR TITLE
Update postmerge to upload to ecr for a tag on the release branch

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@2459e592ef10fe7471bc3e700cea5ab26f5bd34f
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@1fa073ca8427599e5dc8313912fccfdf69e9923d
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -35,3 +35,16 @@ jobs:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}
       NO_AUTH_ECR_PUSH_PASSWD: ${{ secrets.NO_AUTH_ECR_PUSH_PASSWD }}
+
+  download-binary-artifact:
+    name: Download binary artifact
+    needs: post-merge-pipeline
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download built binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: ./binaries

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@b518dfd3654021b47d0fd297ec4d48bea8e3591e
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@2459e592ef10fe7471bc3e700cea5ab26f5bd34f
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@75bf08c973a548ac893f1a632e37d28d3839d7c6
     with:
       run_version_check: true
       run_dep_version_check: false
@@ -31,22 +31,9 @@ jobs:
       run_helm_build: false
       run_helm_push: false
       run_version_tag: true
+      run_artifact_push: true
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}
       NO_AUTH_ECR_PUSH_PASSWD: ${{ secrets.NO_AUTH_ECR_PUSH_PASSWD }}
 
-  download-binary-artifact:
-    name: Download binary artifact
-    needs: post-merge-pipeline
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-    steps:
-      - name: Download built binaries
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          pattern: 'built-binaries-*'
-          path: ./binaries
-      - run: ls -R ./binaries

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@75bf08c973a548ac893f1a632e37d28d3839d7c6
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@b518dfd3654021b47d0fd297ec4d48bea8e3591e
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:
@@ -30,8 +32,8 @@ jobs:
       run_docker_push: false
       run_helm_build: false
       run_helm_push: false
-      run_version_tag: true
-      run_artifact_push: true
+      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
+      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -47,6 +47,6 @@ jobs:
       - name: Download built binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
-          pattern: 'built-binaries-*/build/_output*'
+          pattern: 'built-binaries-*'
           path: ./binaries
       - run: ls -R ./binaries

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -23,7 +23,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@aca0ee91023aba27281e710e2e57956a4d888712
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@a95228137803b756aae327668c115db235802982  # 2026.1.3
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
       id-token: write
       actions: read
-    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@1fa073ca8427599e5dc8313912fccfdf69e9923d
+    uses: open-edge-platform/orch-ci/.github/workflows/post-merge.yml@aca0ee91023aba27281e710e2e57956a4d888712
     with:
       run_version_check: true
       run_dep_version_check: false

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -48,3 +48,4 @@ jobs:
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: ./binaries
+      - run: ls -R ./binaries

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -47,5 +47,6 @@ jobs:
       - name: Download built binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
+          pattern: 'built-binaries-*/build/_output*'
           path: ./binaries
       - run: ls -R ./binaries


### PR DESCRIPTION
This pull request updates the `post-merge.yaml` GitHub Actions workflow to improve how post-merge automation is triggered and managed. The main changes involve expanding workflow triggers, updating the referenced workflow version, and refining the conditions under which certain post-merge steps are executed.

**Workflow trigger improvements:**

* Added support for running the workflow on any tag push, not just branch pushes. (`.github/workflows/post-merge.yaml`)

**Workflow version update:**

* Updated the referenced reusable workflow to a newer commit, ensuring the latest workflow logic is used. (`.github/workflows/post-merge.yaml`)

**Conditional execution enhancements:**

* Changed the `run_version_tag` and added `run_artifact_push` so these steps only run when a tag is pushed from a release branch, making the workflow more robust and preventing unnecessary actions. (`.github/workflows/post-merge.yaml`)