### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -9,6 +9,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow trigger conditions to ensure the workflow runs not only on pushes to certain branches but also on new tags. This makes the workflow more flexible and responsive to tagging events.

**Workflow trigger improvements:**

* [`.github/workflows/post-merge.yaml`](diffhunk://#diff-718495b98036156c667b0e7e9a1bb1535a04a0e87ef400a3274eceb9baff864dR12-R13): Modified the `on.push` section to include all tags (pattern `'*'`) in addition to the existing `main` and `release-*` branches, so the workflow will now also run when a tag is pushed.