### PR TITLE
Remove trigger on tag from post-merge workflows

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -9,8 +9,6 @@ on:
     branches:
       - main
       - release-*
-    tags:
-      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change removes the trigger that would run the workflow on any tag push, so the workflow will now only run on pushes to the `main` and `release-*` branches, or when manually dispatched.

- Removed the workflow trigger for tag pushes in `.github/workflows/post-merge.yaml`