### PR TITLE
Update pre-merge workflow configuration

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: (C) 2025 Intel Corporation
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 name: Pre-Merge CI Pipeline
@@ -56,7 +56,7 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ui/kvm-viewer/package-lock.json
       - name: Pin npm to v10
-        run: npm install -g npm@10
+        run: npm install -g npm@10.9.4
       - name: Build KVM-enabled orch-cli
         run: make build-kvm
   final-check:


### PR DESCRIPTION
This pull request makes a couple of minor updates to the `.github/workflows/pre-merge.yml` file. It updates the copyright year and pins the npm version more precisely.

- Workflow configuration updates:
  * Updated the copyright year in the SPDX header from 2025 to 2026.
  * Pinned the npm version to `10.9.4` instead of just `10` for more precise dependency management.