### PR TITLE
Update pre-merge workflow configuration

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -55,12 +55,13 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: ui/kvm-viewer/package-lock.json
-      - name: Install specific npm version
+      - name: Install hash-pinned npm
         run: |
           curl -fsSL https://registry.npmjs.org/npm/-/npm-10.9.4.tgz -o npm.tgz
-          echo "expected_sha256_hash npm.tgz" | sha256sum -c
-          tar -xzf npm.tgz
-          sudo cp -r package/* /usr/local/
+
+          echo "<SHA512>  npm.tgz" | sha512sum -c -
+
+          npm install -g ./npm.tgz
       - name: Build KVM-enabled orch-cli
         run: make build-kvm
   final-check:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -55,8 +55,12 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: ui/kvm-viewer/package-lock.json
-      - name: Pin npm to v10
-        run: npm install -g npm@10.9.4
+      - name: Install specific npm version
+        run: |
+          curl -fsSL https://registry.npmjs.org/npm/-/npm-10.9.4.tgz -o npm.tgz
+          echo "expected_sha256_hash npm.tgz" | sha256sum -c
+          tar -xzf npm.tgz
+          sudo cp -r package/* /usr/local/
       - name: Build KVM-enabled orch-cli
         run: make build-kvm
   final-check:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           curl -fsSL https://registry.npmjs.org/npm/-/npm-10.9.4.tgz -o npm.tgz
 
-          echo "f33c339aaebd68f7510ed97efc62bbac0b96e8e6  npm.tgz" | sha1sum -c -
+          echo "61e81f9dc6ea559d9173e69aae772bc8fe75c3ce  npm.tgz" | sha1sum -c -
 
           npm install -g ./npm.tgz
       - name: Build KVM-enabled orch-cli

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -55,11 +55,11 @@ jobs:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: ui/kvm-viewer/package-lock.json
-      - name: Install hash-pinned npm
+      - name: Install pinned npm
         run: |
           curl -fsSL https://registry.npmjs.org/npm/-/npm-10.9.4.tgz -o npm.tgz
 
-          echo "<SHA512>  npm.tgz" | sha512sum -c -
+          echo "f33c339aaebd68f7510ed97efc62bbac0b96e8e6  npm.tgz" | sha1sum -c -
 
           npm install -g ./npm.tgz
       - name: Build KVM-enabled orch-cli


### PR DESCRIPTION
This pull request updates how a specific version of `npm` is installed in the pre-merge GitHub Actions workflow. Instead of using `npm install -g`, it now downloads, verifies, and installs the npm package manually to improve security and reliability.

**CI workflow improvements:**

* [`.github/workflows/pre-merge.yml`](diffhunk://#diff-af56bcb95358063aaf895262efbd18c4c2d3451ae42927d7fe8ae4665e175109L58-R63): Replaces the global npm install command with a manual download and SHA256 hash verification of `npm@10.9.4`, then installs it directly to `/usr/local/`. This adds an integrity check and avoids possible issues with `npm install -g`.