### PR TITLE
Handled an external kvm session stop via orch-cli

### DIFF
--- a/internal/cli/kvm_viewer.go
+++ b/internal/cli/kvm_viewer.go
@@ -252,10 +252,12 @@ func (s *kvmSession) readFromMPS() {
 			s.browserConn = nil
 		}
 		s.browserMu.Unlock()
-		// Do NOT close s.done here — session lifecycle is managed only by
-		// serveDisconnect (browser Disconnect button) or ctx.Done (Ctrl+C).
-		// An MPS read error just means AMT closed the channel; the operator
-		// must explicitly stop the session.
+		// Close the session so startKVMViewer unblocks and runs its full
+		// cleanup regardless of how the MPS connection ended — Ctrl+C,
+		// browser disconnect, or an external `--session-state stop` command
+		// that caused AMT to drop the relay connection.
+		// s.close() is idempotent so double-calls from Ctrl+C or serveDisconnect
+		s.close()
 	}()
 
 	for {
@@ -874,6 +876,35 @@ func startKVMViewer(ctx context.Context, token, mpsDomain, deviceGUID, orchCA st
 	fmt.Printf("\n  %s\n\n", viewerURL)
 	fmt.Println("Press Ctrl+C to stop the KVM session.")
 	go openBrowser(viewerURL)
+
+	// poll orchestrator for an external `--session-state stop` request.
+	// The stop command only patches DesiredKvmState on the backend; AMT does not
+	// immediately drop the MPS relay, so readFromMPS never exits on its own.
+	// This goroutine detects the change within ~5 s and calls sess.close() so
+	// startKVMViewer unblocks and runs the normal cleanup path.
+	go func() {
+		ticker := time.NewTicker(5 * time.Second)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-sess.done:
+				return
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				getResp, err := hostClient.HostServiceGetHostWithResponse(ctx, projectName, hostID, auth.AddAuthHeader)
+				if err != nil {
+					continue
+				}
+				if getResp.JSON200 != nil && getResp.JSON200.DesiredKvmState != nil &&
+					*getResp.JSON200.DesiredKvmState == infra.KVMSTATESTOP {
+					logf("[KVM] External stop detected (DesiredKvmState=stop) — closing session")
+					sess.close()
+					return
+				}
+			}
+		}
+	}()
 
 	// Step 4 — wait for session to end (MPS disconnect, ctx cancel, or browser disconnect)
 	select {


### PR DESCRIPTION
## Description
Handled an external kvm session stop via orch-cli

## Changes
<img width="1077" height="27" alt="image" src="https://github.com/user-attachments/assets/e86a0e65-b9ed-48da-8332-d638064a7844" />
<img width="787" height="672" alt="image" src="https://github.com/user-attachments/assets/bd2eb8af-3239-44a5-96a8-8a4d9bad541e" />
<img width="1815" height="387" alt="image" src="https://github.com/user-attachments/assets/3c4a7a18-2f05-4d17-a0fe-bd1c706a8699" />
<img width="550" height="193" alt="image" src="https://github.com/user-attachments/assets/785fc1c3-d97a-4fc7-8833-d1d59e872c8a" />

Earlier these 3 scenarios  are handled :

1. Ctrl +C 
2. Browser clicks Disconnect
3. Incase MPS relay drops

As part of this changes handled kvm session stop via orch-cli

1. External  --session-state stop via orch-cli

Handled all 4 scenarios 

1. Ctrl +C 
2. Browser clicks Disconnect
3. External  --session-state stop
4. Incase MPS relay drops

List the changes you have made.

## Additional Information

Include any additional information, such as how to test your changes.

## Checklist

- [ ] Tests passed
- [ ] Documentation updated
