### PR TITLE
Update Makefile to include license files in tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PKG     	:= github.com/open-edge-platform/cli
 OCI_REPOSITORY 	:= edge-orch/files/orch-cli
 OCI_REGISTRY    ?= 080137407410.dkr.ecr.us-west-2.amazonaws.com
 VERSION         ?= $(shell cat ./VERSION)
-ARTIFACT_FILES := src ./binaries/build/_output/orch-cli
+ARTIFACT_FILES := src ./signed-package
 
 RELEASE_DIR     ?= release
 RELEASE_NAME    ?= orch-cli
@@ -231,7 +231,8 @@ license: reuse-tool
 
 artifact-publish:
 	@echo "TAR orch-cli."
-	tar -czvf orch-cli-package.tar.gz $(ARTIFACT_FILES)
+	cp -R LICENSES $(ARTIFACT_FILES)
+    tar -czvf orch-cli-package.tar.gz $(ARTIFACT_FILES)
 
 	@echo "Publishing orch-cli-package.tar.gz to Production Release Service."
 	aws ecr create-repository --region us-west-2 --repository-name ${OCI_REPOSITORY} || true


### PR DESCRIPTION
This pull request updates the packaging process for the `orch-cli` artifact to align with new requirements for artifact contents and licensing. The most significant changes are related to what files are included in the release package and ensuring license compliance.

Packaging process updates:

* The `ARTIFACT_FILES` variable in the `Makefile` now points to `src` and `./signed-package` instead of `src` and `./binaries/build/_output/orch-cli`, changing which files are bundled in the release artifact.
* During the `artifact-publish` step, the `LICENSES` directory is now copied into the artifact files before packaging, ensuring license files are included in the release tarball.