### PR TITLE
Update Makefile to use tag_name instead or version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG     	:= github.com/open-edge-platform/cli
 
 OCI_REPOSITORY 	:= edge-orch/files/orch-cli
 OCI_REGISTRY    ?= 080137407410.dkr.ecr.us-west-2.amazonaws.com
-VERSION         ?= $(shell cat ./VERSION)
+TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 ARTIFACT_FILES := ./signed-package
 
 ORAS_VERSION = 1.2.0
@@ -246,7 +246,7 @@ artifact-publish: oras-dependency
 	else \
 		aws ecr create-repository --region us-west-2 --repository-name ${OCI_REPOSITORY}; \
 	fi
-	oras push ${OCI_REGISTRY}/${OCI_REPOSITORY}:$(VERSION) ./orch-cli-package.tar.gz
+	oras push ${OCI_REGISTRY}/${OCI_REPOSITORY}:$(TAG) ./orch-cli-package.tar.gz
 
 oras-dependency:
 	@# Help: Install oras if not present


### PR DESCRIPTION
This pull request updates the `Makefile` to use a Git tag-based versioning system for publishing artifacts instead of reading the version from the `VERSION` file. The main impact is that published artifacts will now be tagged with the latest Git tag or "dev" if no tag is found.

Versioning and artifact publishing updates:

* Changed the `TAG` variable to use the latest Git tag (or "dev" as a fallback) instead of reading from the `VERSION` file in the `Makefile`.
* Updated the artifact publishing command to use `$(TAG)` instead of `$(VERSION)` when pushing to the OCI registry.