### PR TITLE
Use github tag name for ECR tag

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -27,7 +27,6 @@ jobs:
     with:
       run_version_check: true
       run_dep_version_check: false
-      run_version_dev: true
       run_build: true
       run_docker_build: false
       run_docker_push: false

--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -27,6 +27,7 @@ jobs:
     with:
       run_version_check: true
       run_dep_version_check: false
+      run_version_dev: true
       run_build: true
       run_docker_build: false
       run_docker_push: false
@@ -34,8 +35,8 @@ jobs:
       run_helm_push: false
       bin_zip_name: Orch-cli-package
       bin_path: ./orch-cli-package.tar.gz    
-      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
-      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
+      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/v202') }}
+      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/v202') }}
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}


### PR DESCRIPTION
This pull request updates the workflow conditions in `.github/workflows/post-merge.yaml` to simplify and clarify when version tagging and artifact pushing steps should run. The main change is to trigger these steps only for tags that start with `v202`, instead of also requiring the base reference to be a release branch.

**Workflow condition updates:**

* Updated `run_version_tag` and `run_artifact_push` to trigger when the Git reference starts with `refs/tags/v202`, removing the previous requirement for the base reference to be a release branch.