### PR TITLE
Update to use github tag name for ECR tag

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -33,9 +33,9 @@ jobs:
       run_helm_build: false
       run_helm_push: false
       bin_zip_name: Orch-cli-package
-      bin_path: ./orch-cli-package.tar.gz    
-      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
-      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
+      bin_path: ./orch-cli-package.tar.gz
+      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/v202') }}
+      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/v202') }}
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}


### PR DESCRIPTION
This pull request updates the workflow conditions in `.github/workflows/post-merge.yaml` to simplify and clarify when version tagging and artifact pushing steps are executed. The main change is to trigger these steps based solely on the tag format, rather than both tag and branch name.

**Workflow condition simplification:**

* Updated `run_version_tag` and `run_artifact_push` to trigger when the Git reference starts with `refs/tags/v202`, instead of requiring both a tag and a release branch.