### PR TITLE
Update to use github tag name for ERC tag

### DIFF
--- a/.github/workflows/post-merge.yaml
+++ b/.github/workflows/post-merge.yaml
@@ -33,9 +33,9 @@ jobs:
       run_helm_build: false
       run_helm_push: false
       bin_zip_name: Orch-cli-package
-      bin_path: ./orch-cli-package.tar.gz    
-      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
-      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/') && startsWith(github.event.base_ref, 'refs/heads/release-') }}
+      bin_path: ./orch-cli-package.tar.gz
+      run_version_tag: ${{ startsWith(github.ref, 'refs/tags/v202') }}
+      run_artifact_push: ${{ startsWith(github.ref, 'refs/tags/v202') }}
     secrets:
       SYS_EMF_GH_TOKEN: ${{ secrets.SYS_EMF_GH_TOKEN }}
       NO_AUTH_ECR_PUSH_USERNAME: ${{ secrets.NO_AUTH_ECR_PUSH_USERNAME }}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ PKG     	:= github.com/open-edge-platform/cli
 
 OCI_REPOSITORY 	:= edge-orch/files/orch-cli
 OCI_REGISTRY    ?= 080137407410.dkr.ecr.us-west-2.amazonaws.com
-VERSION         ?= $(shell cat ./VERSION)
+TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 ARTIFACT_FILES := ./signed-package
 
 ORAS_VERSION = 1.2.0
@@ -246,7 +246,7 @@ artifact-publish: oras-dependency
 	else \
 		aws ecr create-repository --region us-west-2 --repository-name ${OCI_REPOSITORY}; \
 	fi
-	oras push ${OCI_REGISTRY}/${OCI_REPOSITORY}:$(VERSION) ./orch-cli-package.tar.gz
+	oras push ${OCI_REGISTRY}/${OCI_REPOSITORY}:$(TAG) ./orch-cli-package.tar.gz
 
 oras-dependency:
 	@# Help: Install oras if not present


### PR DESCRIPTION
This pull request updates the version tagging and artifact publishing logic to use Git tags and simplifies the Makefile's version handling. The main changes focus on improving how release versions are detected and used for artifact publishing.

**CI/CD workflow improvements:**

* [`.github/workflows/post-merge.yaml`](diffhunk://#diff-718495b98036156c667b0e7e9a1bb1535a04a0e87ef400a3274eceb9baff864dL37-R38): Updated the conditions for `run_version_tag` and `run_artifact_push` to trigger only when the Git ref starts with `refs/tags/v202`, making the workflow more specific to the intended versioning scheme.

**Makefile and artifact versioning:**

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L10-R10): Changed the artifact tag variable from `VERSION` (read from the `VERSION` file) to `TAG`, which now uses the latest Git tag or defaults to `dev` if none is found. This ensures artifacts are tagged consistently with Git releases.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L249-R249): Updated the `oras push` command to use the new `TAG` variable instead of `VERSION`, aligning pushed artifact tags with Git tags.